### PR TITLE
Adding alter hook for modifying items while processing entities.

### DIFF
--- a/createapi.api.php
+++ b/createapi.api.php
@@ -237,3 +237,29 @@ function hook_createapi_variables() {
   );
 }
 
+/**
+ * Alter the output of an entity before it's added to a feed.
+ *
+ * CreateAPI automatically will prepare fields, properties, and path information
+ * based on hook_createapi_custom_entities_info() and other related hooks that
+ * define feed information. For properties that aren't supported by CreateAPI or
+ * for properties that need additional modification, this hook may be used
+ * to add or modify information on an individual item's output.
+ *
+ * @param array $item
+ *   The associative array containing the item that will be JSON encoded.
+ * @param stdClass $entity
+ *   The entity for the item being output.
+ *
+ * @see _createapi__helper__process_entities()
+ */
+function hook_createapi_process_entity_alter(&$item, $entity) {
+  if (isset($item['type']) && $item['type'] == 'photo') {
+    // Remove HTML tags for app delivery.
+    $item['description'] = strip_tags($item['description']);
+
+    // Check if this entity is flagged.
+    $flag = flag_get_flag('promoted');
+    $item['promoted'] = $flag->is_flagged($entity->nid);
+  }
+}

--- a/createapi.helpers.inc
+++ b/createapi.helpers.inc
@@ -52,6 +52,8 @@ function _createapi__helper__process_entities(array $eids, $entity_type, $fields
       }
     }
 
+    drupal_alter('createapi_process_entity', $field_output, $entity);
+
     $output[] = $field_output;
   }
 


### PR DESCRIPTION
While using this project I encountered limitations where it's difficult to add or modify properties in feed items generated. This PR adds a hook for modifying items before they get output. A few example are included in the documentation on why you might want use this, e.g. adding information about flags from Flag module, or massaging output by adding/removing encoding.

p.s. There's no issue tracker enabled for this project(?)
