### PR TITLE
Add support for boolean fields which may have a 0 value

### DIFF
--- a/createapi.helpers.filters.inc
+++ b/createapi.helpers.filters.inc
@@ -18,7 +18,7 @@ function _createapi__helper__filter__property(&$query, $param, $property) {
   $query_params = drupal_get_query_parameters();
   $param_value = (isset($query_params[$param])) ? $query_params[$param] : FALSE;
 
-  if ($param_value) {
+  if ($param_value !== FALSE) {
     $param_value_split = explode(',', $param_value);
     $type = get_class($query);
     switch ($type) {


### PR DESCRIPTION
`_createapi__helper__filter__property()` has the following logic to add a filter condition:

```
 $param_value = (isset($query_params[$param])) ? $query_params[$param] : FALSE;

if ($param_value) {
   $param_value_split = explode(',', $param_value);
```

If the field you are filtering to is a checkbox whose possible values are 0 or 1 and if you filter by `value = 0`, the above `if` statement ill fail and your filter won't be added. We should strictly check that the value is `FALSE`.
